### PR TITLE
fix(visitor): ignore DW_AT_decl_file/line in visit_namespace

### DIFF
--- a/src/dwarf2cpp/visitor.py
+++ b/src/dwarf2cpp/visitor.py
@@ -216,6 +216,9 @@ class Visitor:
         namespace = Namespace(name=die.short_name)
 
         for attribute in die.attributes:
+            if attribute.name in {"DW_AT_decl_file", "DW_AT_decl_line"}:
+                continue
+
             match attribute.name:
                 case "DW_AT_name":
                     pass


### PR DESCRIPTION
## Summary

`visit_namespace` crashed with `ValueError: Unhandled attribute DW_AT_decl_file` on binaries whose namespace DIEs carry a declaration location.

Namespace DIEs can include `DW_AT_decl_file` / `DW_AT_decl_line` (where the namespace was first declared), but the attribute `match` in `visit_namespace` had no skip-set, so those attributes fell through to the catch-all `case _:` and raised. Every other visitor (`visit_typedef`, `visit_enumeration_type`, …) already skips these declaration-location attributes.

This adds the same `if attribute.name in {...}: continue` skip-set to `visit_namespace`. The attributes are safely ignored: a namespace does not need a source location (namespaces re-open across files); its members each carry their own.

Closes #13

## Test plan

- [ ] Run `dwarf2cpp` on a binary whose namespaces carry `DW_AT_decl_file` (the case from #13) and confirm it no longer raises.